### PR TITLE
Backup rulesets

### DIFF
--- a/protect_default.json
+++ b/protect_default.json
@@ -1,0 +1,43 @@
+{
+  "id": 1051884,
+  "name": "protect_default",
+  "target": "branch",
+  "source_type": "Organization",
+  "source": "pcdshub",
+  "enforcement": "evaluate",
+  "conditions": {
+    "repository_property": {
+      "exclude": [],
+      "include": [
+        {
+          "name": "protect_default",
+          "source": "custom",
+          "property_values": [
+            "true"
+          ]
+        }
+      ]
+    },
+    "ref_name": {
+      "exclude": [
+        "refs/heads/master",
+        "refs/heads/gh-pages"
+      ],
+      "include": [
+        "~ALL"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "creation"
+    }
+  ],
+  "bypass_actors": []
+}

--- a/protect_gh_pages.json
+++ b/protect_gh_pages.json
@@ -1,0 +1,34 @@
+{
+  "id": 1051877,
+  "name": "protect_gh_pages",
+  "target": "branch",
+  "source_type": "Organization",
+  "source": "pcdshub",
+  "enforcement": "evaluate",
+  "conditions": {
+    "repository_property": {
+      "exclude": [],
+      "include": [
+        {
+          "name": "protect_gh_pages",
+          "source": "custom",
+          "property_values": [
+            "true"
+          ]
+        }
+      ]
+    },
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/gh-pages"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    }
+  ],
+  "bypass_actors": []
+}

--- a/protect_master.json
+++ b/protect_master.json
@@ -1,0 +1,51 @@
+{
+  "id": 1045151,
+  "name": "protect_master",
+  "target": "branch",
+  "source_type": "Organization",
+  "source": "pcdshub",
+  "enforcement": "evaluate",
+  "conditions": {
+    "repository_property": {
+      "exclude": [],
+      "include": [
+        {
+          "name": "protect_master",
+          "source": "custom",
+          "property_values": [
+            "true"
+          ]
+        }
+      ]
+    },
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH",
+        "refs/heads/master"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "creation"
+    }
+  ],
+  "bypass_actors": []
+}

--- a/python_status_checks.json
+++ b/python_status_checks.json
@@ -1,0 +1,58 @@
+{
+  "id": 1051916,
+  "name": "python_status_checks",
+  "target": "branch",
+  "source_type": "Organization",
+  "source": "pcdshub",
+  "enforcement": "evaluate",
+  "conditions": {
+    "repository_property": {
+      "exclude": [],
+      "include": [
+        {
+          "name": "required_checks",
+          "source": "custom",
+          "property_values": [
+            "Python Standard"
+          ]
+        }
+      ]
+    },
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH",
+        "refs/heads/master"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "standard / Conda (3.10) / Python 3.10: conda"
+          },
+          {
+            "context": "standard / Conda (3.9, true) / Python 3.9: conda"
+          },
+          {
+            "context": "standard / Documentation / Python 3.9: documentation building"
+          },
+          {
+            "context": "standard / Pip (3.10) / Python 3.10: pip"
+          },
+          {
+            "context": "standard / Pip (3.9, true) / Python 3.9: pip"
+          },
+          {
+            "context": "standard / pre-commit checks / pre-commit"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/twincat_status_checks.json
+++ b/twincat_status_checks.json
@@ -1,0 +1,49 @@
+{
+  "id": 1051917,
+  "name": "twincat_status_checks",
+  "target": "branch",
+  "source_type": "Organization",
+  "source": "pcdshub",
+  "enforcement": "evaluate",
+  "conditions": {
+    "repository_property": {
+      "exclude": [],
+      "include": [
+        {
+          "name": "required_checks",
+          "source": "custom",
+          "property_values": [
+            "TwinCAT Standard"
+          ]
+        }
+      ]
+    },
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH",
+        "refs/heads/master"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "standard / Documentation / Python 3.9: documentation building"
+          },
+          {
+            "context": "standard / pragma linting / Pragma Linting"
+          },
+          {
+            "context": "standard / pytmc summary / Project Summary"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
An initial backup of our rulesets, since if we merge with SLACLAB we probably won't carry these over.

These are still under evaluation, though I haven't disagreed with anything that I've seen so far.  Lots of actions taken fail, but for good reason (improper classification, backup repo cron jobs bypassing protections, etc)

I'll go through and refine the custom property information soon